### PR TITLE
Corepack is enabled to fix yarn version mismatch

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,5 +1,6 @@
 on: [push, pull_request]
 name: Build, Test and Publish
+
 jobs:
   test:
     name: Build & Test
@@ -9,21 +10,28 @@ jobs:
         node-version: [20.x, 19.x, 18.x, 16.x]
     steps:
       - uses: actions/checkout@v3
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Cache node_modules
         id: cache-modules
         uses: actions/cache@v3
         with:
           path: node_modules
           key: ${{ matrix.node-version }}-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
+
       - name: Build
         if: steps.cache-modules.outputs.cache-hit != 'true'
         run: yarn install
       - name: Test
         run: yarn test
+
   publish:
     name: Publish
     needs: test
@@ -31,17 +39,29 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Cache node_modules
         id: cache-modules
         uses: actions/cache@v3
         with:
           path: node_modules
           key: 16.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
+
       - name: Install
         if: steps.cache-modules.outputs.cache-hit != 'true'
         run: yarn install
+
       - name: Build
         run: yarn build
+
       - name: publish
         uses: JS-DevTools/npm-publish@v2
         with:


### PR DESCRIPTION
@thehungrycoder in this PR I updated the CI/CD workflow to address the Yarn version mismatch issue. I have enabled `Corepack` step in both the test and publish jobs, ensuring compatibility with the Yarn version specified in `package.json` 