### PR TITLE
Included a field under corepack

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -18,6 +18,9 @@ jobs:
 
       - name: Enable Corepack
         run: corepack enable
+        with:
+          package: corepack
+          version: 3.2.3
 
       - name: Cache node_modules
         id: cache-modules
@@ -47,6 +50,9 @@ jobs:
 
       - name: Enable Corepack
         run: corepack enable
+        with:
+          package: corepack
+          version: 3.2.3
 
       - name: Cache node_modules
         id: cache-modules


### PR DESCRIPTION
Updated workflow to `with` field under the `Enable Corepack step`, specifying the corepack package and the Yarn version we want to use. 