### PR TITLE
Modified with env

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -18,9 +18,8 @@ jobs:
 
       - name: Enable Corepack
         run: corepack enable
-        with:
-          package: corepack
-          version: 3.2.3
+        env:
+          COREPACK_VERSION: 3.2.3
 
       - name: Cache node_modules
         id: cache-modules
@@ -50,9 +49,8 @@ jobs:
 
       - name: Enable Corepack
         run: corepack enable
-        with:
-          package: corepack
-          version: 3.2.3
+        env:
+          COREPACK_VERSION: 3.2.3
 
       - name: Cache node_modules
         id: cache-modules


### PR DESCRIPTION
In this modification, I added the `COREPACK_VERSION` environment variable when enabling Corepack. This ensures that Corepack uses the specified Yarn version (3.2.3) from our `package.json`