### PR TITLE
Fix GitHub Action publish failure by updating Node to 20.x and adding…

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -38,17 +38,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 16.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '20.x'
 
       - name: Cache node_modules
         id: cache-modules
         uses: actions/cache@v3
         with:
           path: node_modules
-          key: 16.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
+          key: 20.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
 
       - name: Install dependencies
         if: steps.cache-modules.outputs.cache-hit != 'true'
@@ -61,3 +61,4 @@ jobs:
         uses: JS-DevTools/npm-publish@v2
         with:
           token: ${{ secrets.NPM_TOKEN }}
+          access: public


### PR DESCRIPTION
### **Here is the breakdown of why it failed and how the fix works:**

**1. Scoped Packages default to "Private"**
By default, the npm registry assumes that any package with a scope (like @prayersconnect) is a private package.

The Error: When the GitHub Action tried to run npm publish, it tried to publish it as a private package. If your npm account doesn't have a paid "Pro" or "Team" plan for private packages, the registry rejects the request with a 404 Not Found (instead of a "Permission Denied") to avoid leaking the existence of private package names.
The Fix: Adding access: public explicitly tells npm: "Yes, this is a scoped package, but it is intended to be public." This allows the registry to accept the publication on a free account.
**2. Node.js 16 is End-of-Life (EOL)**
Your workflow was using Node 16, which is no longer supported and comes with an older version of npm.

The Problem: Older versions of npm sometimes have trouble communicating with the latest security and API requirements of the registry.npmjs.org. This can occasionally cause misleading errors during the authentication or transmission phase of publishing.
The Fix: Updating to Node 20 (the current Long-Term Support version) ensures you are using the latest npm client. This version is more robust, has better error reporting, and is fully compatible with the current npm registry standards.



… public access flag

Following changes were made:
- Updated Node.js version in Publish job to 20.x for better compatibility with npm registry.
- Added 'access: public' to the JS-DevTools/npm-publish step. This is required for scoped packages (@prayersconnect/configs) on free npm accounts to resolve 404 Not Found errors during publish.