### PR TITLE
Use npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -35,20 +35,24 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Cache node_modules
         id: cache-modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
-          key: 20.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
+          key: 22.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
 
       - name: Install dependencies
         if: steps.cache-modules.outputs.cache-hit != 'true'
@@ -57,8 +61,8 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish
-        uses: JS-DevTools/npm-publish@v2
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Switch publish workflow to npm OIDC trusted publishing (no `NPM_TOKEN` needed)
- Upgrade npm in the runner to a version that supports trusted publishing, and bump `checkout`/`setup-node`/`cache` to v4